### PR TITLE
PLAT-3027: Upgrade version of kaniko used by jenkins-agent-docker-kaniko

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:v0.7.0 as kaniko
+FROM gcr.io/kaniko-project/executor:v0.9.0 as kaniko
 
 FROM dwolla/jenkins-agent-core:alpine
 


### PR DESCRIPTION
Bump version to `v0.9.0`.