### PR TITLE
Fix java.io.FileNotFoundException due to missing /usr/lib/libnss3.so

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ LABEL maintainer="Dwolla Dev <dev+jenkins-agent-kaniko@dwolla.com>" \
 USER root
 
 # Install base packages
-RUN apk update && apk upgrade
 RUN apk add --no-cache --update \
       build-base \
       make

--- a/README.md
+++ b/README.md
@@ -29,8 +29,21 @@ Hub build process. To build the image locally, run `./hooks/build`.
 
 ## Notes
 
+### `UsePerfData`
+
 When invoking `agent.jar` specify `/kaniko` for the `-workDir` option. This
 ensures artifacts included by Jenkins will be whitelisted by `kaniko`. Also,
 if specifying custom options for `JAVA_OPTS`, avoid the use of
 `-XX:+UsePerfData`. Otherwise, a `/tmp/hsperfdata_root` directory will be
 included in the resulting image.
+
+### Invoking `agent.jar`
+
+`jenkins-agent-docker-core:alpine` creates an `ENTRYPOINT` for the Jenkins
+Remoting JAR (`agent.jar`). The Jenkins Remoting JAR can be invoked using the
+following command:
+
+```bash
+docker run dwolla/jenkins-agent-kaniko:latest
+  -url https://ci.dwolla.net/ <SLAVE_NODE_SECRET> <SLAVE_NODE_NAME>
+```


### PR DESCRIPTION
Invoking the Jenkins remoting JAR causes the following error:

```
Apr 17, 2019 7:12:17 PM hudson.remoting.jnlp.Main createEngine
INFO: Setting up slave: admin-xh2jq
Apr 17, 2019 7:12:17 PM hudson.remoting.jnlp.Main$CuiListener <init>
INFO: Jenkins agent is running in headless mode.
Apr 17, 2019 7:12:17 PM hudson.remoting.jnlp.Main$CuiListener status
INFO: Locating server among [https://ci.dwolla.net/]
Apr 17, 2019 7:12:17 PM hudson.remoting.jnlp.Main$CuiListener error
SEVERE: null
java.lang.ExceptionInInitializerError
        at sun.security.ssl.SSLSessionImpl.<init>(SSLSessionImpl.java:188)
        at sun.security.ssl.SSLSessionImpl.<init>(SSLSessionImpl.java:152)
        at sun.security.ssl.SSLSessionImpl.<clinit>(SSLSessionImpl.java:79)
        at sun.security.ssl.SSLSocketImpl.init(SSLSocketImpl.java:598)
        at sun.security.ssl.SSLSocketImpl.<init>(SSLSocketImpl.java:536)
        at sun.security.ssl.SSLSocketFactoryImpl.createSocket(SSLSocketFactoryImpl.java:72)
        at sun.net.www.protocol.https.HttpsClient.createSocket(HttpsClient.java:405)
        at sun.net.NetworkClient.doConnect(NetworkClient.java:162)
        at sun.net.www.http.HttpClient.openServer(HttpClient.java:463)
        at sun.net.www.http.HttpClient.openServer(HttpClient.java:558)
        at sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:264)
        at sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:367)
        at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:191)
        at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1156)
        at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1050)
        at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:177)
        at sun.net.www.protocol.https.HttpsURLConnectionImpl.connect(HttpsURLConnectionImpl.java:162)
        at hudson.remoting.Engine.run(Engine.java:261)
Caused by: java.security.ProviderException: Could not initialize NSS
        at sun.security.pkcs11.SunPKCS11.<init>(SunPKCS11.java:223)
```

This is due to a known issue with Alpine Linux (https://bugs.alpinelinux.org/issues/10126).

In addition, I removed `RUN apk update && apk upgrade` as this goes against [`Dockerfile best practices`](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get).