### PR TITLE
Fix java.io.FileNotFoundException due to missing /usr/lib/libnss3.so.. again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ RUN apk add --no-cache --update \
       tzdata \
       && echo 'gem: --no-document' > /etc/gemrc
 
+# Address 'java.io.FileNotFoundException: /usr/lib/libnss3.so' issue
+# https://bugs.alpinelinux.org/issues/10126
+RUN apk add --no-cache nss
+
 # Install Berkshelf
 RUN gem install --no-rdoc --no-ri berkshelf
 


### PR DESCRIPTION
This issue is back. This is probably due to an upstream change that was incorporated into the latest `jenkins-agent-kaniko` build.