### PR TITLE
Use jenkins/jnlp-slave Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,54 @@
 FROM gcr.io/kaniko-project/executor:v0.11.0 as kaniko
 
-FROM busybox:1.30-glibc as busybox
+FROM busybox:1.31.0 as busybox
 
-FROM dwolla/jenkins-agent-core:debian
+FROM jenkins/jnlp-slave:alpine
 
+ARG BUILD_DATE
 ARG VCS_REF
 ARG VCS_URL
-ARG BUILD_DATE
 ARG VERSION
 
 LABEL maintainer="Dwolla Dev <dev+jenkins-agent-kaniko@dwolla.com>" \
-    org.label-schema.vcs-ref=$VCS_REF \
-    org.label-schema.vcs-url=$VCS_URL \
-    org.label-schema.build-date=$BUILD_DATE \
-    org.label-schema.version=$VERSION
+  org.label-schema.build-date=$BUILD_DATE \
+  org.label-schema.vcs-ref=$VCS_REF \
+  org.label-schema.vcs-url=$VCS_URL \
+  org.label-schema.version=$VERSION
+
+# By default, the JNLP3-connect protocol is disabled due to known stability
+# and scalability issues. You can enable this protocol using the
+# JNLP_PROTOCOL_OPTS environment variable:
+#
+# JNLP_PROTOCOL_OPTS=-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=false
+#
+# The JNLP3-connect protocol should be enabled on the Master instance as well.
+
+ENV JNLP_PROTOCOL_OPTS=-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=false
+
+# Disable the JVM PerfDataFile feature by adding `-XX:-UsePerfData` to the
+# `JAVA_OPTS` environment variable. Otherwise, a superfluous
+# `/tmp/hsperfdata_root` directory will be included in the final Docker image.
+
+ENV JAVA_OPTS -XX:-UsePerfData
 
 # apk and kaniko must be run as root.
 USER root
 
-# Install base packages
-RUN apt-get update && \
-    apt-get remove -y python && \
-    apt autoremove -y && \
-    apt-get install -y --no-install-recommends \
-                ca-certificates \
-                ca-certificates-java \
-                libnss3 \
-      && \
-    apt-get clean
+# Install minimally required packages
+RUN apk add --no-cache --update \
+      build-base \
+      make
 
-# We disable the JVM PerfDataFile feature by adding `-XX:-UsePerfData` to the
-# `JAVA_OPTS` environment variable. Otherwise, an additional
-# `/tmp/hsperfdata_root` directory will show up in images we create.
-ENV JAVA_OPTS -XX:-UsePerfData
+# Install additional packages
+RUN apk add --update --no-cache \
+      curl \
+      python3
+
+# Install the AWS CLI using the bundled installer
+RUN curl 'https://s3.amazonaws.com/aws-cli/awscli-bundle.zip' \
+      -o 'awscli-bundle.zip' && \
+      unzip awscli-bundle.zip && \
+      python3 ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 
 COPY --from=kaniko /kaniko /kaniko
 COPY --from=busybox /bin /busybox
@@ -45,6 +61,6 @@ ENV PATH=/busybox:$PATH
 # Docker image.
 VOLUME /busybox
 
-# The /kaniko directory is whitelisted by default. Its contents is not deleted
-# between stages, nor is it included in the final Docker image.
+# The /kaniko directory is whitelisted by default. Its contents are not de-
+# leted between stages, nor is it included in the final Docker image.
 WORKDIR /kaniko

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Dwolla
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,0 @@
-The MIT License (MIT)
-
-Copyright © 2019 Dwolla
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,49 +1,103 @@
-# Jenkins Agent with kaniko
+# Jenkins Agent Docker Kaniko
 
-[![](https://images.microbadger.com/badges/image/dwolla/jenkins-agent-kaniko.svg)](https://microbadger.com/images/dwolla/jenkins-agent-kaniko)
-[![license](https://img.shields.io/github/license/dwolla/jenkins-agent-docker-kaniko.svg?style=flat-square)](https://github.com/Dwolla/jenkins-agent-docker-kaniko/blob/master/LICENSE.md)
+![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/dwolla/jenkins-agent-docker-kaniko?color=blue)
+[![](https://images.microbadger.com/badges/image/dwolla/jenkins-agent-docker-kaniko.svg)](https://microbadger.com/images/dwolla/jenkins-agent-kaniko)
+[![](https://images.microbadger.com/badges/version/dwolla/jenkins-agent-docker-kaniko.svg)](https://microbadger.com/images/dwolla/jenkins-agent-kaniko)
+![GitHub](https://img.shields.io/github/license/NickolasHKraus/jenkins-agent-docker-kaniko?color=blue)
 
-## Overview
+[Docker Hub](https://cloud.docker.com/u/dwolla/repository/docker/dwolla/jenkins-agent-kaniko)
 
-`jenkins-agent-docker-kaniko` is a Docker image based on [Dwolla’s core
-Jenkins Agent Docker image](https://github.com/Dwolla/jenkins-agent-docker-core).
+Jenkins Agent Docker Kaniko contains the [Jenkins Remoting](https://jenkins.io/projects/remoting/) library and [Kaniko](https://github.com/GoogleContainerTools/kaniko). It can be used with [Amazon EC2 Container Service Plugin](https://wiki.jenkins.io/display/JENKINS/Amazon+EC2+Container+Service+Plugin) to build Docker images from a container running on an Amazon ECS cluster.
 
-It enables Docker images to be built and pushed using
-[kaniko](https://github.com/GoogleContainerTools/kaniko) and provides
-utilities for deploying artifacts.
+## What's in the image?
 
-## Available Utilities
+Jenkins Agent Docker Kaniko contains the following images:
 
-* [`kaniko`](https://github.com/GoogleContainerTools/kaniko)
+### `jenkins/jnlp-slave`
 
-kaniko is a tool to build container images from a Dockerfile inside a
-container or Kubernetes cluster.
+`jenkins/jnlp-slave` contains [Jenkins Remoting](https://github.com/jenkinsci/remoting), a library which implements the communication layer in Jenkins.
 
-* Berkshelf
+[Docker Hub](https://hub.docker.com/r/jenkins/jnlp-slave/) | [GitHub](https://github.com/jenkinsci/docker-jnlp-slave)
 
-[Berkshelf](https://docs.chef.io/berkshelf.html) is a dependency manager for
-Chef cookbooks.
+### `gcr.io/kaniko-project/executor`
 
-The `hooks` directory is provided to customize parts of the automated Docker
-Hub build process. To build the image locally, run `./hooks/build`.
+`gcr.io/kaniko-project/executor` contains [Kaniko](https://github.com/GoogleContainerTools/kaniko), a tool that can build container images from a `Dockerfile` inside a container or Kubernetes cluster without a Docker daemon.
 
-## Notes
+[GitHub](https://github.com/GoogleContainerTools/kaniko)
 
-### `UsePerfData`
+### `busybox`
 
-When invoking `agent.jar` specify `/kaniko` for the `-workDir` option. This
-ensures artifacts included by Jenkins will be whitelisted by `kaniko`. Also,
-if specifying custom options for `JAVA_OPTS`, avoid the use of
-`-XX:+UsePerfData`. Otherwise, a `/tmp/hsperfdata_root` directory will be
-included in the resulting image.
+`busybox` ([busybox.net](https://busybox.net/)) combines tiny versions of many common UNIX utilities into a single small executable.
 
-### Invoking `agent.jar`
+[Docker Hub](https://hub.docker.com/_/busybox)
 
-`jenkins-agent-docker-core:alpine` creates an `ENTRYPOINT` for the Jenkins
-Remoting JAR (`agent.jar`). The Jenkins Remoting JAR can be invoked using the
-following command:
+## Usage
+
+Jenkins Agent Docker Kaniko can be run via Docker using the following command:
 
 ```bash
-docker run dwolla/jenkins-agent-kaniko:latest
-  -url https://ci.dwolla.net/ <SLAVE_NODE_SECRET> <SLAVE_NODE_NAME>
+$ docker run \
+  -it \
+  --rm \
+  -v ~/path/to/repository:/repository: \
+  -v ~/.docker/config.json:/kaniko/.docker/config.json: \
+  -w /repository \
+  dwolla/jenkins-agent-kaniko:latest \
+  /bin/sh
+```
+
+The Kaniko executor can be invoked using the following:
+
+```bash
+IMAGE_ID=registry/repository && \
+IMAGE_TAG=$(git rev-parse HEAD) && \
+export DOCKER_CONFIG=/kaniko/.docker && \
+/kaniko/executor \
+  --context $(pwd) \
+  --dockerfile $(pwd)/Dockerfile \
+  --destination $IMAGE_ID:$IMAGE_TAG \
+  --destination $IMAGE_ID:latest \
+  --force
+```
+
+### Credentials
+
+Kaniko uses the Docker configuration file (typically `$HOME/.docker/config.json`) for configuration and authentication.
+
+In order to provide Kaniko with this file, `config.json` can be mounted from the host:
+
+```bash
+docker run \
+  ...
+  -v ~/.docker/config.json:/kaniko/.docker/config.json: \
+```
+
+The path to `config.json` can then be set using the `DOCKER_CONFIG` environment variable:
+
+```bash
+export DOCKER_CONFIG=/kaniko/.docker
+```
+
+It should be noted that `config.json` is mounted within `/kaniko`, since this directory is whitelisted by Kaniko and therefore its contents are persisted between stages.
+
+### Credentials Management
+
+Kaniko works by fetching and extracting the filesystem of a Docker image (designated by the `FROM` instruction) to root (`/`). It executes each command in order and takes a snapshot of the filesystem after each command. This snapshot is created in user space by walking the filesystem and comparing it to the prior state that was stored in memory. It appends any modifications to the filesystem as a new layer to the base image and makes any relevant changes to image metadata. After executing every command in the `Dockerfile`, the executor pushes the newly built image to the desired registry.
+
+The Kaniko executor image is built from scratch and contains only a static Go binary plus the configuration files needed for pushing and pulling images. As such, it is normally invoked directly and not included in an image as a new build stage. We have found that images built using a Docker image that includes the Kaniko executor as a dependency (`FROM gcr.io/kaniko-project/executor:v0.10.0 as kaniko`) *may* differ from those built using Docker.
+
+For this reason, it is recommended that you include as few utilities or libraries as possible it the Kaniko image.
+
+However, if, for example, you need access to AWS CLI in order to pull `config.json` or secrets from an S3 bucket, you can do so using the following:
+
+```Dockerfile
+RUN apk add --update --no-cache \
+      curl \
+      python3
+
+# install the AWS CLI using the bundled installer
+RUN curl 'https://s3.amazonaws.com/aws-cli/awscli-bundle.zip' \
+      -o 'awscli-bundle.zip' && \
+      unzip awscli-bundle.zip && \
+      python3 ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 ```

--- a/hooks/build
+++ b/hooks/build
@@ -7,8 +7,8 @@ BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 VCS_URL="https://github.com/Dwolla/jenkins-agent-docker-kaniko"
 
 docker build \
+	--build-arg BUILD_DATE="$BUILD_DATE" \
 	--build-arg VCS_REF="$GIT_SHA1" \
 	--build-arg VCS_URL="$VCS_URL" \
-	--build-arg BUILD_DATE="$BUILD_DATE" \
 	--build-arg VERSION="$GIT_SHA1" \
 	-t "$IMAGE_NAME" .

--- a/hooks/env
+++ b/hooks/env
@@ -4,4 +4,4 @@
 # them ourselves.
 : "${GIT_SHA1:=$(git rev-parse -q HEAD)}"
 : "${DOCKER_REPO:=dwolla/jenkins-agent-kaniko}"
-: "${IMAGE_NAME:=dwolla/jenkins-agent-kaniko:${GIT_SHA1}-SNAPSHOT}"
+: "${IMAGE_NAME:=${DOCKER_REPO}:${GIT_SHA1}-SNAPSHOT}"


### PR DESCRIPTION
This pull request removes our dependency on [jenkins-agent-docker-nucleus](https://github.com/Dwolla/jenkins-agent-docker-nucleus) and [jenkins-agent-docker-core](https://github.com/Dwolla/jenkins-agent-docker-core) by including [jenkins/jnlp-slave](https://hub.docker.com/r/jenkins/jnlp-slave/) directly.